### PR TITLE
Apply shared header includes and add build step

### DIFF
--- a/1 Homepage.html
+++ b/1 Homepage.html
@@ -44,45 +44,7 @@
 
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero" id="home">
@@ -610,4 +572,3 @@
 </body>
 
 </html>
-```

--- a/2 Issues.html
+++ b/2 Issues.html
@@ -20,48 +20,7 @@
     <script src="https://js.givebutter.com/elements/latest.js"></script>
 </head>
 <body>
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-    
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-    
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-    
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <!-- PROBLEM: Crisis Hero Section -->

--- a/3 About.html
+++ b/3 About.html
@@ -21,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">

--- a/4 Programs.html
+++ b/4 Programs.html
@@ -1,4 +1,3 @@
-```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">
@@ -375,4 +336,3 @@
     </script>
 </body>
 </html>
-```

--- a/4A prison_oversight_page.html
+++ b/4A prison_oversight_page.html
@@ -1,4 +1,3 @@
-```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">
@@ -278,4 +239,3 @@
     </script>
 </body>
 </html>
-```

--- a/4B criminal_legal_reform_page.html
+++ b/4B criminal_legal_reform_page.html
@@ -1,4 +1,3 @@
-```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">
@@ -293,4 +254,3 @@
     </script>
 </body>
 </html>
-```

--- a/4C drug_policy_page.html
+++ b/4C drug_policy_page.html
@@ -1,4 +1,3 @@
-```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">
@@ -346,4 +307,3 @@
     </script>
 </body>
 </html>
-```

--- a/4D civic_engagement_page.html
+++ b/4D civic_engagement_page.html
@@ -1,4 +1,3 @@
-```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">
@@ -321,4 +282,3 @@
     </script>
 </body>
 </html>
-```

--- a/4E arts_in_prison_page.html
+++ b/4E arts_in_prison_page.html
@@ -21,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">

--- a/5 Action Center.html
+++ b/5 Action Center.html
@@ -1,4 +1,3 @@
-```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">
@@ -289,4 +250,3 @@
     </script>
 </body>
 </html>
-```

--- a/6 Partners.html
+++ b/6 Partners.html
@@ -1,4 +1,3 @@
-```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -20,45 +19,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">
@@ -95,7 +56,7 @@
         </section>
     </main>
 
-    <footer class="footer" role="contentinfo"></footer>
+    <footer id="global-footer" role="contentinfo"></footer>
 
     <script src="js/components.js"></script>
     <script>
@@ -115,4 +76,3 @@
     </script>
 </body>
 </html>
-```

--- a/7 News.html
+++ b/7 News.html
@@ -21,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <section class="hero">
         <div class="container">

--- a/8 Contact.html
+++ b/8 Contact.html
@@ -19,45 +19,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">
@@ -99,7 +61,7 @@
         </div>
     </main>
 
-    <footer class="footer" role="contentinfo"></footer>
+    <footer id="global-footer" role="contentinfo"></footer>
 
     <script src="js/components.js"></script>
     <script>

--- a/9 Donate.html
+++ b/9 Donate.html
@@ -21,45 +21,7 @@
 </head>
 <body>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                    <div class="dropdown">
-                        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-                        <div class="dropdown-menu">
-                            <a href="4A prison_oversight_page.html">Prison Oversight</a>
-                            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-                            <a href="4C drug_policy_page.html">Drug Policy</a>
-                            <a href="4D civic_engagement_page.html">Civic Engagement</a>
-                            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="nav-links-row">
-                    <a href="5 Action Center.html">Action Center</a>
-                    <a href="6 Partners.html">Partners</a>
-                    <a href="7 News.html">News</a>
-                    <a href="8 Contact.html">Contact</a>
-                    <a href="#blog">Blog</a>
-                </div>
-            </nav>
-            <div class="header-cta">
-                <givebutter-widget id="jbkZBL"></givebutter-widget>
-            </div>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu" aria-expanded="false">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero">

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Edit files in the `/includes/` directory:
    ```
 3. Add CSS link and components.js script
 
+### Building the Site
+Run `npm run build` to generate a `dist/` directory with static pages.
+Deploy the contents of `dist/` to your hosting provider.
+
 ### Styling
 Main styles are in `/css/styles.css`. Use CSS variables for consistent colors:
 - `--primary-navy`: #000080

--- a/css-test.html
+++ b/css-test.html
@@ -47,19 +47,7 @@
         </div>
     </div>
     
-    <header class="header">
-        <div class="header-container">
-            <div class="header-logo">
-                <h3>Header Test</h3>
-            </div>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="#">Test Link 1</a>
-                    <a href="#">Test Link 2</a>
-                </div>
-            </nav>
-        </div>
-    </header>
+    <div id="global-header"></div>
     
     <main style="padding-top: 120px;">
         <section class="section">

--- a/homepage-test.html
+++ b/homepage-test.html
@@ -14,25 +14,7 @@
         🔴 CSS TEST - If you see this red box, HTML is loading!
     </div>
 
-    <header class="header">
-        <div class="header-container">
-            <a href="1 Homepage.html" class="header-logo">
-                <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img">
-            </a>
-            <nav class="header-nav">
-                <div class="nav-links-row">
-                    <a href="1 Homepage.html">Home</a>
-                    <a href="2 Issues.html">Issues</a>
-                    <a href="3 About.html">About</a>
-                </div>
-            </nav>
-            <button class="mobile-menu-toggle" aria-label="Open navigation menu">
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-                <span class="hamburger-bar"></span>
-            </button>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
     <main id="main-content" role="main">
         <section class="hero" id="home">
@@ -72,7 +54,7 @@
         </section>
     </main>
 
-    <footer class="footer">
+    <footer id="global-footer" role="contentinfo">
         <div class="container">
             <div class="footer-content">
                 <div>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Praxis Initiative static site",
   "main": "index.js",
   "scripts": {
-    "release": "standard-version"
+    "release": "standard-version",
+    "build": "node scripts/build.js"
   },
   "devDependencies": {
     "standard-version": "^9.5.0"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,48 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+async function copyDir(src, dest) {
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath);
+    } else {
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+async function build() {
+  const root = __dirname.replace(/scripts$/, '');
+  const dist = path.join(root, 'dist');
+  await fs.rm(dist, { recursive: true, force: true });
+  await fs.mkdir(dist);
+
+  const header = await fs.readFile(path.join(root, 'includes', 'header.html'), 'utf8');
+  const footer = await fs.readFile(path.join(root, 'includes', 'footer.html'), 'utf8');
+
+  const files = await fs.readdir(root);
+  for (const file of files) {
+    if (!file.endsWith('.html')) continue;
+    const filePath = path.join(root, file);
+    let html = await fs.readFile(filePath, 'utf8');
+    html = html.replace('<div id="global-header"></div>', header);
+    html = html.replace(/<footer id="global-footer"[^>]*><\/footer>/, footer);
+    await fs.writeFile(path.join(dist, file), html);
+  }
+
+  for (const dir of ['css', 'js', '10 Assets']) {
+    const srcDir = path.join(root, dir);
+    if (await fs.stat(srcDir).catch(() => false)) {
+      await copyDir(srcDir, path.join(dist, dir));
+    }
+  }
+}
+
+build().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- remove stray code-fence markers from HTML pages
- replace duplicated header markup with `<div id="global-header"></div>` placeholders
- ensure all pages use `<footer id="global-footer">`
- add a simple Node build script and `npm run build`
- document the build command in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883ea53f71c8324870ec7dd933036c7