### PR TITLE
Fix global header layout across site

### DIFF
--- a/includes/header.html
+++ b/includes/header.html
@@ -1,36 +1,41 @@
 <!-- Header -->
 <header class="header">
-  <div class="header-row-1">
-    <a href="1 Homepage.html" class="logo logo-link">
-      <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img" loading="eager">
-    </a>
-    <nav class="nav-row-1">
-      <a href="1 Homepage.html">Home</a>
-      <a href="2 Issues.html">Issues</a>
-      <a href="3 About.html">About</a>
-      <div class="dropdown">
-        <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
-        <div class="dropdown-menu">
-          <a href="4A prison_oversight_page.html">Prison Oversight</a>
-          <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
-          <a href="4C drug_policy_page.html">Drug Policy</a>
-          <a href="4D civic_engagement_page.html">Civic Engagement</a>
-          <a href="4E arts_in_prison_page.html">Arts in Prison</a>
+  <div class="header-container">
+    <div class="header-logo">
+      <a href="1 Homepage.html" class="logo-link">
+        <img src="10 Assets/Praxis Logos/Praxis Logo New Italic Tagline Navy Transparent BG 1078 x 218.png" alt="Praxis Initiative Logo" class="logo-img" loading="eager">
+      </a>
+    </div>
+    <nav class="header-nav">
+      <div class="nav-links-row">
+        <a href="1 Homepage.html">Home</a>
+        <a href="2 Issues.html">Issues</a>
+        <a href="3 About.html">About</a>
+        <div class="dropdown">
+          <a href="4 Programs.html" class="dropdown-toggle">Programs &#9662;</a>
+          <div class="dropdown-menu">
+            <a href="4A prison_oversight_page.html">Prison Oversight</a>
+            <a href="4B criminal_legal_reform_page.html">Criminal Legal Reform</a>
+            <a href="4C drug_policy_page.html">Drug Policy</a>
+            <a href="4D civic_engagement_page.html">Civic Engagement</a>
+            <a href="4E arts_in_prison_page.html">Arts in Prison</a>
+          </div>
         </div>
+        <a href="5 Action Center.html">Action Center</a>
+        <a href="6 Partners.html">Partners</a>
+        <a href="7 News.html">News</a>
+        <a href="8 Contact.html">Contact</a>
+        <a href="#blog">Blog</a>
       </div>
     </nav>
-    <div class="givebutter-btn">
+    <div class="header-cta">
       <givebutter-widget id="jbkZBL"></givebutter-widget>
     </div>
-  </div>
-  <div class="header-row-2">
-    <nav class="nav-row-2">
-      <a href="5 Action Center.html">Action Center</a>
-      <a href="6 Partners.html">Partners</a>
-      <a href="7 News.html">News</a>
-      <a href="8 Contact.html">Contact</a>
-      <a href="#blog">Blog</a>
-    </nav>
+    <button class="mobile-menu-toggle" aria-label="Toggle navigation" aria-expanded="false">
+      <span class="hamburger-bar"></span>
+      <span class="hamburger-bar"></span>
+      <span class="hamburger-bar"></span>
+    </button>
   </div>
 </header>
 <!-- End Header -->

--- a/js/components-clean.js
+++ b/js/components-clean.js
@@ -44,7 +44,7 @@ class ComponentLoader {
 
     setActiveNavItem() {
         // Set active navigation item based on current page
-        const navLinks = document.querySelectorAll('.header-nav a, .nav-row-1 a, .nav-row-2 a');
+        const navLinks = document.querySelectorAll('.header-nav a');
         navLinks.forEach(link => {
             const href = link.getAttribute('href');
             if (href && href.includes(this.currentPage)) {

--- a/js/components.js
+++ b/js/components.js
@@ -44,7 +44,7 @@ class ComponentLoader {
 
     setActiveNavItem() {
         // Set active navigation item based on current page
-        const navLinks = document.querySelectorAll('.header-nav a, .nav-row-1 a, .nav-row-2 a');
+        const navLinks = document.querySelectorAll('.header-nav a');
         navLinks.forEach(link => {
             const href = link.getAttribute('href');
             if (href && href.includes(this.currentPage)) {


### PR DESCRIPTION
## Summary
- update `header.html` to use a single row layout with a Programs dropdown and donation button
- adjust component loader scripts so navigation items rely only on `.header-nav` links

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68848b0be2908324ba2c2899afaf993a