### PR TITLE
Audit hero and quote sections

### DIFF
--- a/2 Issues.html
+++ b/2 Issues.html
@@ -53,50 +53,50 @@
                 <p class="centered-paragraph max-width-800">These aren't just numbers. They're fathers, mothers, sons, daughters—people who deserve dignity, accountability, and the chance to return home safely.</p>
                 
                 <div class="stories-grid">
-                    <div class="story-card">
-                        <div class="story-quote">
-                            "I watched my son die slowly from treatable diabetes because the prison refused to provide insulin. He was 34 years old. He had two years left on his sentence."
-                        </div>
-                        <div class="story-attribution">
+                    <figure class="story-card">
+                        <blockquote class="story-quote">
+                            I watched my son die slowly from treatable diabetes because the prison refused to provide insulin. He was 34 years old. He had two years left on his sentence.
+                        </blockquote>
+                        <figcaption class="story-attribution">
                             <div class="story-avatar">
-                                <i class="fas fa-user"></i>
+                                <i class="fas fa-user" aria-hidden="true"></i>
                             </div>
                             <div>
-                                <div class="story-author">Maria Santos</div>
-                                <div class="story-context">Mother of deceased inmate</div>
+                                <span class="story-author">Maria Santos</span>
+                                <span class="story-context">Mother of deceased inmate</span>
                             </div>
-                        </div>
-                    </div>
+                        </figcaption>
+                    </figure>
 
-                    <div class="story-card">
-                        <div class="story-quote">
-                            "The heat was unbearable. 118°F inside the cells. No working air conditioning for weeks. Three men in my unit suffered heat stroke in one day."
-                        </div>
-                        <div class="story-attribution">
+                    <figure class="story-card">
+                        <blockquote class="story-quote">
+                            The heat was unbearable. 118°F inside the cells. No working air conditioning for weeks. Three men in my unit suffered heat stroke in one day.
+                        </blockquote>
+                        <figcaption class="story-attribution">
                             <div class="story-avatar">
-                                <i class="fas fa-user"></i>
+                                <i class="fas fa-user" aria-hidden="true"></i>
                             </div>
                             <div>
-                                <div class="story-author">James Mitchell</div>
-                                <div class="story-context">Formerly incarcerated, Lewis Prison</div>
+                                <span class="story-author">James Mitchell</span>
+                                <span class="story-context">Formerly incarcerated, Lewis Prison</span>
                             </div>
-                        </div>
-                    </div>
+                        </figcaption>
+                    </figure>
 
-                    <div class="story-card">
-                        <div class="story-quote">
-                            "I filed 17 grievances about my husband's chest pain. They said he was 'faking it.' He died of a heart attack two weeks before his release date."
-                        </div>
-                        <div class="story-attribution">
+                    <figure class="story-card">
+                        <blockquote class="story-quote">
+                            I filed 17 grievances about my husband's chest pain. They said he was 'faking it.' He died of a heart attack two weeks before his release date.
+                        </blockquote>
+                        <figcaption class="story-attribution">
                             <div class="story-avatar">
-                                <i class="fas fa-user"></i>
+                                <i class="fas fa-user" aria-hidden="true"></i>
                             </div>
                             <div>
-                                <div class="story-author">Patricia Williams</div>
-                                <div class="story-context">Widow and advocate</div>
+                                <span class="story-author">Patricia Williams</span>
+                                <span class="story-context">Widow and advocate</span>
                             </div>
-                        </div>
-                    </div>
+                        </figcaption>
+                    </figure>
                 </div>
             </div>
         </section>

--- a/3 About.html
+++ b/3 About.html
@@ -29,11 +29,10 @@
                 <div class="hero-content">
                     <div class="hero-image">
                         <p>Community members working together<br>for criminal justice reform</p>
-                        <div class="hero-quote">
-                            "People closest to the problem are closest to the solution but furthest from power and resources."
-                            <br><br>
-                            <strong>— Glenn E. Martin</strong>
-                        </div>
+                        <blockquote class="hero-quote">
+                            <p>People closest to the problem are closest to the solution but furthest from power and resources.</p>
+                            <cite>— Glenn E. Martin</cite>
+                        </blockquote>
                     </div>
                     <div class="hero-text">
                         <div class="section-label">Empowering Communities Through Justice</div>

--- a/4 Programs.html
+++ b/4 Programs.html
@@ -54,8 +54,10 @@
 
         <section class="baldwin-quote">
             <div class="container">
-                <div class="quote-text">"Not everything that is faced can be changed, but nothing can be changed until it is faced."</div>
-                <div class="quote-author">— James Baldwin</div>
+                <blockquote class="quote-text">
+                    Not everything that is faced can be changed, but nothing can be changed until it is faced.
+                </blockquote>
+                <cite class="quote-author">— James Baldwin</cite>
             </div>
         </section>
 

--- a/4D civic_engagement_page.html
+++ b/4D civic_engagement_page.html
@@ -173,29 +173,35 @@
                 <p class="section-subtitle fade-in">Alumni making a difference in their communities and in policy reform</p>
 
                 <div class="stories-grid">
-                    <div class="story-card fade-in">
+                    <figure class="story-card fade-in">
                         <blockquote class="story-quote">
-                            "This program didn't just teach me how to advocate—it helped me find my voice and understand that my experience matters in shaping policy. Now I'm testifying at the state capitol and helping other returning citizens understand their power."
+                            This program didn't just teach me how to advocate—it helped me find my voice and understand that my experience matters in shaping policy. Now I'm testifying at the state capitol and helping other returning citizens understand their power.
                         </blockquote>
-                        <div class="story-author">Maria R.</div>
-                        <div class="story-title">Program Graduate, Legislative Advocate</div>
-                    </div>
+                        <figcaption>
+                            <span class="story-author">Maria R.</span>
+                            <span class="story-title">Program Graduate, Legislative Advocate</span>
+                        </figcaption>
+                    </figure>
 
-                    <div class="story-card fade-in">
+                    <figure class="story-card fade-in">
                         <blockquote class="story-quote">
-                            "Learning how government actually works was transformative. I went from feeling powerless to understanding exactly how to create change. The skills I learned here helped me get elected to my city council."
+                            Learning how government actually works was transformative. I went from feeling powerless to understanding exactly how to create change. The skills I learned here helped me get elected to my city council.
                         </blockquote>
-                        <div class="story-author">David L.</div>
-                        <div class="story-title">City Council Member, Community Leader</div>
-                    </div>
+                        <figcaption>
+                            <span class="story-author">David L.</span>
+                            <span class="story-title">City Council Member, Community Leader</span>
+                        </figcaption>
+                    </figure>
 
-                    <div class="story-card fade-in">
+                    <figure class="story-card fade-in">
                         <blockquote class="story-quote">
-                            "The mentorship and training gave me confidence to share my story with policymakers. My testimony helped pass legislation expanding reentry services. That's the power of lived experience in policy."
+                            The mentorship and training gave me confidence to share my story with policymakers. My testimony helped pass legislation expanding reentry services. That's the power of lived experience in policy.
                         </blockquote>
-                        <div class="story-author">Jennifer T.</div>
-                        <div class="story-title">Policy Advocate, Nonprofit Director</div>
-                    </div>
+                        <figcaption>
+                            <span class="story-author">Jennifer T.</span>
+                            <span class="story-title">Policy Advocate, Nonprofit Director</span>
+                        </figcaption>
+                    </figure>
                 </div>
             </div>
         </section>

--- a/4E arts_in_prison_page.html
+++ b/4E arts_in_prison_page.html
@@ -141,12 +141,12 @@
                         <p>Participants report significant improvements in self-esteem, emotional regulation, and interpersonal relationships. The program has also contributed to reduced disciplinary incidents and improved mental health outcomes among participants.</p>
                     </div>
 
-                    <div class="spotlight-visual fade-in">
+                    <figure class="spotlight-visual fade-in">
                         <blockquote class="spotlight-quote">
-                            "Through movement, I found my voice again. This program gave me tools to heal that I never knew existed."
+                            Through movement, I found my voice again. This program gave me tools to heal that I never knew existed.
                         </blockquote>
-                        <cite class="spotlight-author">— Think Motion Program Participant</cite>
-                    </div>
+                        <figcaption class="spotlight-author">— Think Motion Program Participant</figcaption>
+                    </figure>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- switch quote sections from `div` to semantic `blockquote` markup
- add `<figure>` and `<figcaption>` to attribute testimonials
- use `<cite>` for quote authors

## Testing
- `npm run build`
- `npx htmlhint '2 Issues.html' '3 About.html' '4 Programs.html' '4D civic_engagement_page.html' '4E arts_in_prison_page.html'` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884bb59145c8324b9761f802444c309